### PR TITLE
Fix migration not creating tables

### DIFF
--- a/db/migrate/001_create_toggl_time_entries.rb
+++ b/db/migrate/001_create_toggl_time_entries.rb
@@ -1,6 +1,9 @@
 class CreateTogglTimeEntries < ActiveRecord::Migration
   def change
     create_table :toggl_time_entries do |t|
+      t.column :id, :integer
     end
+
+    add_index :toggl_time_entries, [:id], :name => "id"
   end
 end


### PR DESCRIPTION
We added an explicit table definition, otherwise the table was not created and the plug-in was not working correctly.
