### PR TITLE
set api key not visible to not show it on users/show

### DIFF
--- a/db/migrate/003_set_api_key_not_visible.rb
+++ b/db/migrate/003_set_api_key_not_visible.rb
@@ -1,0 +1,16 @@
+class SetApiKeyNotVisible < ActiveRecord::Migration
+
+  def up
+    custom_field = CustomField.find_by_name('Toggl API Key')
+    custom_field.visible = false
+    custom_field.save!
+  end
+
+  def down
+    custom_field = CustomField.find_by_name('Toggl API Key')
+    custom_field.visible = true
+    custom_field.save!
+  end
+
+end
+


### PR DESCRIPTION
API key custom field is created with visible = true by default. This causes it to be exposed on the /users/:user_id and members see each others Toggl keys. Also if you allow public access to your Redmine instance (even if you have at least one public project) the API keys are visible by everyone. This migration changes the custom field to not visible.