### PR TITLE
Allow filtering by workspace

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -24,6 +24,7 @@ Then add the following line to your crontab (schedule may vary, of course):
 == How to use
 
 First, go to your Redmine profile and set your Toggl API key. You can get one at https://www.toggl.com/user/edit.
+If you want to use only some of your Toggl workspaces, you can set them up in Redmine as a comma separated string. To fetch entries from all workspaces, just leave workspace setting empty.
 
 After that any entry in Toggl marked with a hash and a number goes to the corresponding task in your projects. For example, an entry "Going out with Sarah #1324" of 2.5 hours will add 2.5h to the issue #1324 with the "Going out with Sarah" comment.
 

--- a/app/models/toggl_sync_service.rb
+++ b/app/models/toggl_sync_service.rb
@@ -1,17 +1,18 @@
 # Responsible for toggl sync across all the users
 class TogglSyncService
-  
+
   def sync
     User.all.each do |user|
       next if !user.active? || user.locked?
       toggl_api_key = user.custom_field_value(UserCustomField.find_by_name('Toggl API Key'))
       next if toggl_api_key.nil? || toggl_api_key.empty?
-      
-      api = TogglAPIService.new(toggl_api_key)
+      toggl_workspace = user.custom_field_value(UserCustomField.find_by_name('Toggl Workspace'))
+
+      api = TogglAPIService.new(toggl_api_key, toggl_workspace)
       time_registration_service = TogglTimeRegistrationService.new(user, api)
       time_registration_service.sync
     end
-    
+
   end
-  
+
 end

--- a/db/migrate/004_create_workspace_field.rb
+++ b/db/migrate/004_create_workspace_field.rb
@@ -1,0 +1,24 @@
+class CreateWorkspaceField < ActiveRecord::Migration
+
+  def up
+    custom_field = CustomField.new_subclass_instance('UserCustomField', {
+      :name => 'Toggl Workspace',
+      :field_format => 'string',
+      :min_length => 0,
+      :max_length => 255,
+      :regexp => '',
+      :default_value => '',
+      :is_required => false,
+      :visible => false,
+      :editable => true,
+      :is_filter => false
+    })
+
+    custom_field.save!
+  end
+
+  def down
+    CustomField.find_by_name('Toggl Workspace').destroy
+  end
+
+end


### PR DESCRIPTION
Sometimes the same Toggl user puts time entries into different workspaces in Toggl, and wants them to be synchronized by different Redmine instances. These can be different projects, different customers etc. This PR adds support for defining workspaces that will be synchronized.

If the custom field is empty, all workspaces are synchronized. If it has a value setup, it can be one workspace name, or multiple workspace names separated by comma.
