### PR TITLE
time entry activity is set based on toggl tags

### DIFF
--- a/app/models/toggl_api_entry.rb
+++ b/app/models/toggl_api_entry.rb
@@ -1,3 +1,3 @@
 # Holds all the information that we gather from Toggl
-class TogglAPIEntry < Struct.new(:id, :issue_id, :started_at, :duration, :description)
+class TogglAPIEntry < Struct.new(:id, :issue_id, :started_at, :duration, :description, :activity_name)
 end

--- a/app/models/toggl_api_service.rb
+++ b/app/models/toggl_api_service.rb
@@ -21,12 +21,18 @@ class TogglAPIService
     get_latest_toggl_entries_api_response('time_entries').map { |entry|
       if entry["description"] =~ /\s*#(\d+)\s*/ && !entry["stop"].nil? && !entry["stop"].empty? &&
       (@toggl_workspace.blank? || workspace_ids.include?(entry['wid']))
+        
+        activity_name = nil
+        if entry.has_key?("tags") and not entry["tags"].empty?
+          activity_name = entry["tags"].first
+        end         
 
         TogglAPIEntry.new(entry["id"],
                           $1.to_i,
                           Time.parse(entry["start"]),
                           entry["duration"].to_f / 3600,
-                          entry["description"].gsub(/\s*#\d+\s*/, '')
+                          entry["description"].gsub(/\s*#\d+\s*/, ''),
+                          activity_name
                           )
       else
         nil

--- a/app/models/toggl_time_registration_service.rb
+++ b/app/models/toggl_time_registration_service.rb
@@ -30,6 +30,12 @@ protected
     if issue
       time_entry = TimeEntry.new(:project => issue.project, :issue => issue, :user => user, :spent_on => toggl_entry.started_at, :comments => toggl_entry.description)
       time_entry.hours = toggl_entry.duration
+      unless toggl_entry.activity_name.nil?
+        activity_id = TimeEntryActivity.where(name: toggl_entry.activity_name).pluck(:id).first
+        unless activity_id.nil?
+          time_entry.activity_id = activity_id
+        end
+      end
       if !time_entry.valid?
         puts "Creating time entry for issue ##{toggl_entry.issue_id} failed."
         puts "Time entry field values:"


### PR DESCRIPTION
Searching for the first tag from toggl entry in redmine TimeEntryActivity. If such activity exists it will be used instead of default. I am not experienced in ruby so I suppose that it may be done in more efficient way.

Tested for environment:
  Redmine version                3.1.1.stable
  Ruby version                      2.2.3-p173 (2015-08-18) [x86_64-linux]
  Rails version                      4.2.4
