### PR TITLE
New Feature: New rake task to report missmatch Redmine-Toggl entries …

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -19,6 +19,12 @@ Then add the following line to your crontab (schedule may vary, of course):
 
   59 23 * * * cd /path/to/redmine && RAILS_ENV=production bundle exec rake toggl:update
 
+If you want report of missmatch redmine-toggl entries sent with email:
+
+  59 23 * * * cd /path/to/redmine && RAILS_ENV=production bundle exec rake toggl:report[24,"en","admin1@redmine.com,admin2@redmine.com"]
+
+First parameter sets time interval (hours), second parameter is language(currently only supports tr and en) and the last parameter sets mail address (you can use multiple e-mail addresses just split them with comma).
+
 *IMPORTANT*: You should have default activity set in your Redmine. It could be found at http://your.redmine.com/enumerations address under the "Activities" section.
 
 == How to use

--- a/app/models/toggl_api_service.rb
+++ b/app/models/toggl_api_service.rb
@@ -34,6 +34,25 @@ class TogglAPIService
     }.compact
   end
 
+  # Get all user entries with or without # key
+  def get_missmatch_toggl_entries(time_interval)
+    get_latest_toggl_entries_api_response('time_entries').map { |entry|
+      if !entry['stop'].blank? &&
+      time_interval < DateTime.parse(entry['start']) &&
+      !TogglTimeEntry.where(id: entry['id']).any?
+
+      TogglAPIEntry.new(entry["id"],
+                        $1.to_i,
+                        Time.parse(entry["start"]),
+                        entry["duration"].to_f / 3600,
+                        entry["description"]
+                        )
+      else
+        nil
+      end
+    }.compact
+  end
+
 protected
 
   def get_latest_toggl_entries_api_response(target)

--- a/app/models/toggl_report_service.rb
+++ b/app/models/toggl_report_service.rb
@@ -1,0 +1,12 @@
+# Responsible for syncing Toggl with Redmine
+class TogglReportService
+
+  def initialize(toggl_api_service, time_interval)
+    @toggl_api_service = toggl_api_service
+    @time_interval = time_interval
+  end
+
+  def sync
+    missmatch_toggl_entries = @toggl_api_service.get_missmatch_toggl_entries(@time_interval)
+  end
+end

--- a/app/models/toggl_sync_service.rb
+++ b/app/models/toggl_sync_service.rb
@@ -15,4 +15,21 @@ class TogglSyncService
 
   end
 
+  def report(cc_mails, lang, time_interval)
+    # Initialize a hash for keep users and their missmatch Toggl entries
+    all_users_missmatch_toggl_entries = Hash.new
+
+    User.active.each do |user|
+      toggl_api_key = user.custom_field_value(UserCustomField.find_by_name('Toggl API Key'))
+      next if toggl_api_key.blank?
+      toggl_workspace = user.custom_field_value(UserCustomField.find_by_name('Toggl Workspace'))
+
+      api = TogglAPIService.new(toggl_api_key, toggl_workspace)
+      toggl_report_service = TogglReportService.new(api, time_interval)
+      all_users_missmatch_toggl_entries[user] = toggl_report_service.sync
+    end
+    # Send all users missmatch toggl entry reports to CC mails.
+    Mailer.toggl_missmatch_report_mail(cc_mails, lang, all_users_missmatch_toggl_entries).deliver
+  end
+
 end

--- a/app/views/mailer/toggl_missmatch_report_mail.html.erb
+++ b/app/views/mailer/toggl_missmatch_report_mail.html.erb
@@ -1,0 +1,20 @@
+<h3><%=l(:label_mail_header) %></h3>
+<% if @all_users_missmatch_toggl_entries.values.all? {|value| value.blank?} %>
+  <p>
+    <%= l(:journal_no_missmatch_entry) %>
+  </p>
+<% else %>
+  <% @all_users_missmatch_toggl_entries.keys.each do |users| %>
+    <% unless @all_users_missmatch_toggl_entries[users].blank? %>
+      <hr>
+      <b><%= l(:label_user) %>: <%= users %></b> <br>
+      <% @all_users_missmatch_toggl_entries[users].each do |entry| %>
+        <p>
+          <b><%= l(:label_date) %>: </b><%= entry["started_at"].strftime("%d/%m/%Y %H:%M") %><br>
+          <b><%= l(:label_description) %>: </b><%= entry["description"].blank? ? l(:journal_no_description) : entry["description"] %><br>
+          <b><%= l(:label_duration) %>: </b><%= entry["duration"].to_f.round(2)%> <%= l(:label_hours) %><br>
+        </p>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/mailer/toggl_missmatch_report_mail.text.erb
+++ b/app/views/mailer/toggl_missmatch_report_mail.text.erb
@@ -1,0 +1,18 @@
+Toggl-Redmine Missmatch Report
+<% if @all_users_missmatch_toggl_entries.values.all? {|value| value.blank?} %>
+  <%= l(:journal_no_missmatch_entry) %>
+<% else %>
+  <% @all_users_missmatch_toggl_entries.keys.each do |users| %>
+    <% unless @all_users_missmatch_toggl_entries[users].blank? %>
+    ---------------------------------------------------------
+
+    <%= l(:label_user) %>: <%= users %>
+      <% @all_users_missmatch_toggl_entries[users].each do |entry| %>
+      <%= l(:label_date) %>: <%= entry["started_at"].strftime("%d/%m/%Y %H:%M") %>
+      <%= l(:label_description) %>: <%= entry["description"].blank? ? l(:journal_no_description) : entry["description"] %>
+      <%= l(:label_duration) %>: <%= entry["duration"].to_f.round(2)%> hours
+
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,11 @@
 # English strings go here for Rails i18n
 en:
-  # my_label: "My label"
+  label_mail_header: "Toggl-Redmine Missmatch Report"
+  label_user: "User"
+  label_date: "Date"
+  label_description: "Description"
+  label_duration: "Duration"
+  label_hours: "hours"
+
+  journal_no_description: "There is no descripton."
+  journal_no_missmatch_entry: "There isn't any missmatch entry for users."

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -1,0 +1,11 @@
+# Turkish strings go here for Rails i18n
+tr:
+  label_mail_header: "Toggl-Redmine Eşleşmeyen Girdiler Raporu"
+  label_user: "Kullanıcı"
+  label_date: "Tarih"
+  label_description: "Açıklama"
+  label_duration: "Süre"
+  label_hours: "saat"
+
+  journal_no_description: "Açıklama bilgisi girilmemiş."
+  journal_no_missmatch_entry: "Kullanıcıların eşleşmeyen girdisi bulunamadı."

--- a/init.rb
+++ b/init.rb
@@ -6,3 +6,14 @@ Redmine::Plugin.register :toggl do
   url 'http://github.com/skywriter/toggl'
   author_url 'http://uniqsystems.ru/'
 end
+
+Rails.configuration.to_prepare do
+  [
+    [Mailer, Toggl::Patches::MailerPatch]
+  ].each do |classname, modulename|
+    unless classname.included_modules.include?(modulename)
+      classname.send(:include, modulename)
+    end
+  end
+
+end

--- a/lib/tasks/toggl.rake
+++ b/lib/tasks/toggl.rake
@@ -1,8 +1,19 @@
 namespace :toggl do
-  
+
   desc "update Toggl information"
   task :update => [:environment] do
     TogglSyncService.new.sync
   end
-  
+
+  desc "report missmatch Toggl and Redmine entries"
+  task :report, [:time_interval, :lang, :cc_mails] => [:environment, :update] do |t, args|
+    unless args.time_interval && args.cc_mails
+      fail "You need the specify time_interval, language and cc_mail(s)."
+    end
+    time_interval = (Time.now - args.time_interval.to_i.hours)
+    lang = args.lang
+    # Rake splits arguments with comma, join them together to use
+    cc_mails = "#{args.cc_mails}, #{args.extras.join(', ')}"
+    TogglSyncService.new.report(cc_mails, lang, time_interval)
+	end
 end

--- a/lib/toggl/patches/mailer_patch.rb
+++ b/lib/toggl/patches/mailer_patch.rb
@@ -1,0 +1,29 @@
+require_dependency 'mailer'
+
+
+module Toggl
+  module Patches
+    module MailerPatch
+      def self.included(base) # :nodoc:
+        # base.extend(ClassMethods)
+        base.send(:include, InstanceMethods)
+
+        base.class_eval do
+          unloadable  # to make sure plugin is loaded in development mode
+        end
+      end
+
+      module InstanceMethods
+
+        def toggl_missmatch_report_mail(cc_mails, lang, all_users_missmatch_toggl_entries)
+          @all_users_missmatch_toggl_entries = all_users_missmatch_toggl_entries
+          I18n.locale = lang
+
+          mail :to => cc_mails,
+            :subject => 'Toggl-Redmine Missmatch Report'
+        end
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hello,

My name is Okan Binli and i'm doing internship at ÖzgürYazilim A.Ş. at the moment. We use your plugin to keep synchronized between toggl-redmine. But from time to time, users forget to add # key to their Toggl time entry description. Because of that we need to manually check it these mistakes.

They give me this issue as a project to automate this and i think i completed it. What've i done is simply:
- Create new rake task with parameters
- Create new method in Sync Service for iterating each user like you do
- For every user, check every time_entry_id for if it is already added to db. Because; if it has # key, your plugin saved them to database with their id.
- For every user, use initialized empty hash to keep user and their Toggl Time Entries
- Format all the information i have and send them as a mail to given parameter.

Also my rask take checks time_interval value and uses localization(en and tr only for now).

Since this is my first approach to contribute to real open source project; i might made mistakes. If you can tell them to me, i'll immediately work to make them right.

Thanks for your interest and have a good day.
