### PR TITLE
Fix Rails version

### DIFF
--- a/db/migrate/001_create_toggl_time_entries.rb
+++ b/db/migrate/001_create_toggl_time_entries.rb
@@ -1,4 +1,4 @@
-class CreateTogglTimeEntries < ActiveRecord::Migration
+class CreateTogglTimeEntries < Rails.version < '5.1' ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
   def change
     create_table :toggl_time_entries do |t|
     end

--- a/db/migrate/002_create_api_key_field.rb
+++ b/db/migrate/002_create_api_key_field.rb
@@ -1,4 +1,4 @@
-class CreateApiKeyField < ActiveRecord::Migration
+class CreateApiKeyField < Rails.version < '5.1' ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
 
   def up
     custom_field = CustomField.new_subclass_instance('UserCustomField', {

--- a/db/migrate/003_set_api_key_not_visible.rb
+++ b/db/migrate/003_set_api_key_not_visible.rb
@@ -1,4 +1,4 @@
-class SetApiKeyNotVisible < ActiveRecord::Migration
+class SetApiKeyNotVisible < Rails.version < '5.1' ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
 
   def up
     custom_field = CustomField.find_by_name('Toggl API Key')

--- a/db/migrate/004_create_workspace_field.rb
+++ b/db/migrate/004_create_workspace_field.rb
@@ -1,4 +1,4 @@
-class CreateWorkspaceField < ActiveRecord::Migration
+class CreateWorkspaceField < Rails.version < '5.1' ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
 
   def up
     custom_field = CustomField.new_subclass_instance('UserCustomField', {


### PR DESCRIPTION
fresh plugin download (from master branch) was failing on `RAILS_ENV=production bundle exec rake redmine:plugins:migrate`

command output:

```bash
W, [2019-02-17T10:42:16.153731 #99]  WARN -- : Creating scope :sorted. Overwriting existing method Group.sorted.
W, [2019-02-17T10:42:16.163726 #99]  WARN -- : Creating scope :sorted. Overwriting existing method User.sorted.
W, [2019-02-17T10:42:16.164433 #99]  WARN -- : Creating scope :having_mail. Overwriting existing method User.having_mail.
W, [2019-02-17T10:42:16.391772 #99]  WARN -- : Creating scope :system. Overwriting existing method Enumeration.system.
W, [2019-02-17T10:42:18.614172 #99]  WARN -- : DEPRECATION WARNING: Using a dynamic :action segment in a route is deprecated and will be removed in Rails 6.0. (called from instance_eval at /usr/src/redmine/config/routes.rb:355)
W, [2019-02-17T10:42:18.615276 #99]  WARN -- : DEPRECATION WARNING: Using a dynamic :action segment in a route is deprecated and will be removed in Rails 6.0. (called from instance_eval at /usr/src/redmine/config/routes.rb:355)
W, [2019-02-17T10:42:18.615982 #99]  WARN -- : DEPRECATION WARNING: Using a dynamic :action segment in a route is deprecated and will be removed in Rails 6.0. (called from instance_eval at /usr/src/redmine/config/routes.rb:355)
W, [2019-02-17T10:42:18.616699 #99]  WARN -- : DEPRECATION WARNING: Using a dynamic :action segment in a route is deprecated and will be removed in Rails 6.0. (called from instance_eval at /usr/src/redmine/config/routes.rb:355)
W, [2019-02-17T10:42:18.617437 #99]  WARN -- : DEPRECATION WARNING: Using a dynamic :action segment in a route is deprecated and will be removed in Rails 6.0. (called from instance_eval at /usr/src/redmine/config/routes.rb:355)
W, [2019-02-17T10:42:18.618176 #99]  WARN -- : DEPRECATION WARNING: Using a dynamic :action segment in a route is deprecated and will be removed in Rails 6.0. (called from instance_eval at /usr/src/redmine/config/routes.rb:355)
W, [2019-02-17T10:42:18.618878 #99]  WARN -- : DEPRECATION WARNING: Using a dynamic :action segment in a route is deprecated and will be removed in Rails 6.0. (called from instance_eval at /usr/src/redmine/config/routes.rb:355)
I, [2019-02-17T10:42:18.952935 #99]  INFO -- : Migrating to CreateTogglTimeEntries (1)
rake aborted!
StandardError: An error has occurred, all later migrations canceled:

Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:

  class CreateTogglTimeEntries < ActiveRecord::Migration[4.2]
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:528:in `inherited'
/usr/src/redmine/plugins/toggl/db/migrate/001_create_toggl_time_entries.rb:1:in `<top (required)>'
/usr/local/bundle/gems/activesupport-5.2.2/lib/active_support/dependencies.rb:291:in `require'
/usr/local/bundle/gems/activesupport-5.2.2/lib/active_support/dependencies.rb:291:in `block in require'
/usr/local/bundle/gems/activesupport-5.2.2/lib/active_support/dependencies.rb:257:in `load_dependency'
/usr/local/bundle/gems/activesupport-5.2.2/lib/active_support/dependencies.rb:291:in `require'
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:986:in `load_migration'
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:982:in `migration'
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:977:in `disable_ddl_transaction'
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:1350:in `use_transaction?'
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:1342:in `ddl_transaction'
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:1291:in `execute_migration_in_transaction'
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:1263:in `block in migrate_without_lock'
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:1262:in `each'
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:1262:in `migrate_without_lock'
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:1210:in `block in migrate'
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:1363:in `with_advisory_lock'
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:1210:in `migrate'
/usr/src/redmine/lib/redmine/plugin.rb:498:in `up'
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:1011:in `migrate'
/usr/src/redmine/lib/redmine/plugin.rb:530:in `migrate_plugin'
/usr/src/redmine/lib/redmine/plugin.rb:471:in `migrate'
/usr/src/redmine/lib/redmine/plugin.rb:485:in `block in migrate'
/usr/src/redmine/lib/redmine/plugin.rb:484:in `each'
/usr/src/redmine/lib/redmine/plugin.rb:484:in `migrate'
/usr/src/redmine/lib/tasks/redmine.rake:135:in `block (3 levels) in <top (required)>'
/usr/local/bundle/gems/rake-12.3.2/exe/rake:27:in `<top (required)>'
/usr/local/bin/bundle:23:in `load'
/usr/local/bin/bundle:23:in `<main>'

Caused by:
StandardError: Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:

  class CreateTogglTimeEntries < ActiveRecord::Migration[4.2]
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:528:in `inherited'
/usr/src/redmine/plugins/toggl/db/migrate/001_create_toggl_time_entries.rb:1:in `<top (required)>'
/usr/local/bundle/gems/activesupport-5.2.2/lib/active_support/dependencies.rb:291:in `require'
/usr/local/bundle/gems/activesupport-5.2.2/lib/active_support/dependencies.rb:291:in `block in require'
/usr/local/bundle/gems/activesupport-5.2.2/lib/active_support/dependencies.rb:257:in `load_dependency'
/usr/local/bundle/gems/activesupport-5.2.2/lib/active_support/dependencies.rb:291:in `require'
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:986:in `load_migration'
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:982:in `migration'
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:977:in `disable_ddl_transaction'
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:1350:in `use_transaction?'
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:1342:in `ddl_transaction'
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:1291:in `execute_migration_in_transaction'
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:1263:in `block in migrate_without_lock'
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:1262:in `each'
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:1262:in `migrate_without_lock'
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:1210:in `block in migrate'
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:1363:in `with_advisory_lock'
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:1210:in `migrate'
/usr/src/redmine/lib/redmine/plugin.rb:498:in `up'
/usr/local/bundle/gems/activerecord-5.2.2/lib/active_record/migration.rb:1011:in `migrate'
/usr/src/redmine/lib/redmine/plugin.rb:530:in `migrate_plugin'
/usr/src/redmine/lib/redmine/plugin.rb:471:in `migrate'
/usr/src/redmine/lib/redmine/plugin.rb:485:in `block in migrate'
/usr/src/redmine/lib/redmine/plugin.rb:484:in `each'
/usr/src/redmine/lib/redmine/plugin.rb:484:in `migrate'
/usr/src/redmine/lib/tasks/redmine.rake:135:in `block (3 levels) in <top (required)>'
/usr/local/bundle/gems/rake-12.3.2/exe/rake:27:in `<top (required)>'
/usr/local/bin/bundle:23:in `load'
/usr/local/bin/bundle:23:in `<main>'
Tasks: TOP => redmine:plugins:migrate
(See full trace by running task with --trace)
```

this change fixes it as the command output after fix looks like this:

```bash
W, [2019-02-17T10:44:37.070192 #111]  WARN -- : Creating scope :sorted. Overwriting existing method Group.sorted.
W, [2019-02-17T10:44:37.080356 #111]  WARN -- : Creating scope :sorted. Overwriting existing method User.sorted.
W, [2019-02-17T10:44:37.081402 #111]  WARN -- : Creating scope :having_mail. Overwriting existing method User.having_mail.
W, [2019-02-17T10:44:37.308423 #111]  WARN -- : Creating scope :system. Overwriting existing method Enumeration.system.
W, [2019-02-17T10:44:39.216932 #111]  WARN -- : DEPRECATION WARNING: Using a dynamic :action segment in a route is deprecated and will be removed in Rails 6.0. (called from instance_eval at /usr/src/redmine/config/routes.rb:355)
W, [2019-02-17T10:44:39.217892 #111]  WARN -- : DEPRECATION WARNING: Using a dynamic :action segment in a route is deprecated and will be removed in Rails 6.0. (called from instance_eval at /usr/src/redmine/config/routes.rb:355)
W, [2019-02-17T10:44:39.218223 #111]  WARN -- : DEPRECATION WARNING: Using a dynamic :action segment in a route is deprecated and will be removed in Rails 6.0. (called from instance_eval at /usr/src/redmine/config/routes.rb:355)
W, [2019-02-17T10:44:39.218791 #111]  WARN -- : DEPRECATION WARNING: Using a dynamic :action segment in a route is deprecated and will be removed in Rails 6.0. (called from instance_eval at /usr/src/redmine/config/routes.rb:355)
W, [2019-02-17T10:44:39.219412 #111]  WARN -- : DEPRECATION WARNING: Using a dynamic :action segment in a route is deprecated and will be removed in Rails 6.0. (called from instance_eval at /usr/src/redmine/config/routes.rb:355)
W, [2019-02-17T10:44:39.220310 #111]  WARN -- : DEPRECATION WARNING: Using a dynamic :action segment in a route is deprecated and will be removed in Rails 6.0. (called from instance_eval at /usr/src/redmine/config/routes.rb:355)
W, [2019-02-17T10:44:39.220684 #111]  WARN -- : DEPRECATION WARNING: Using a dynamic :action segment in a route is deprecated and will be removed in Rails 6.0. (called from instance_eval at /usr/src/redmine/config/routes.rb:355)
I, [2019-02-17T10:44:39.507812 #111]  INFO -- : Migrating to CreateTogglTimeEntries (1)
== 1 CreateTogglTimeEntries: migrating ========================================
-- adapter_name()
   -> 0.0000s
-- adapter_name()
   -> 0.0000s
-- adapter_name()
   -> 0.0000s
-- create_table(:toggl_time_entries, {:options=>"ENGINE=InnoDB", :id=>:integer})
   -> 0.0200s
== 1 CreateTogglTimeEntries: migrated (0.0205s) ===============================

I, [2019-02-17T10:44:39.548701 #111]  INFO -- : Migrating to CreateApiKeyField (2)
== 2 CreateApiKeyField: migrating =============================================
== 2 CreateApiKeyField: migrated (0.0956s) ====================================

I, [2019-02-17T10:44:39.653026 #111]  INFO -- : Migrating to SetApiKeyNotVisible (3)
== 3 SetApiKeyNotVisible: migrating ===========================================
== 3 SetApiKeyNotVisible: migrated (0.0125s) ==================================

I, [2019-02-17T10:44:39.674995 #111]  INFO -- : Migrating to CreateWorkspaceField (4)
== 4 CreateWorkspaceField: migrating ==========================================
== 4 CreateWorkspaceField: migrated (0.0084s) =================================
```